### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.properties.outputs.version }}
       changelog: ${{ steps.properties.outputs.changelog }}


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/intellij_norminette/security/code-scanning/2](https://github.com/DavidLee18/intellij_norminette/security/code-scanning/2)

To fix the issue, we should add a `permissions` block to the `build` job (under jobs.build), restricting its permissions to the minimum required. Based on the steps, this is likely just `contents: read`; if subsequent analysis shows the job needs more permissions, those can be added, but starting at the most restrictive is best practice. 

Concretely:  
- Add the following block beneath `jobs.build` (right under `runs-on: ubuntu-latest`, before `outputs:`):

```yaml
      permissions:
        contents: read
```

No other changes (methods, imports, or definitions) are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
