### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,8 @@ jobs:
     name: Test
     needs: [ build ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
 
       # Check out the current repository


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/intellij_norminette/security/code-scanning/3](https://github.com/DavidLee18/intellij_norminette/security/code-scanning/3)

To address the problem, add a `permissions` block to the `test` job within `.github/workflows/build.yml`. The principle of least privilege should be followed: for a test job that does not push code, update checks, or create releases, set `contents: read`—which is the minimal needed for code checkout and artifact uploads. This block should be placed at the same indentation level as other job keys (`runs-on`, `steps`, etc.) in the `test` job definition. No import or extra definitions are necessary, only a one-line addition to the YAML structure in `.github/workflows/build.yml` at the appropriate location. Existing functionality will not change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
