### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,8 @@ jobs:
     name: Verify plugin
     needs: [ build ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
 
       # Free GitHub Actions Environment Disk Space


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/intellij_norminette/security/code-scanning/4](https://github.com/DavidLee18/intellij_norminette/security/code-scanning/4)

To fix this problem, you should add an explicit `permissions` block with the minimum privileges necessary to the `verify` job, ensuring that the `GITHUB_TOKEN` used in that job has the least privilege needed. Since the job does not push to the repository, interact with issues, create releases, or perform other privileged operations (it only checks out code, runs scripts, caches, and uploads build/test artifacts), `contents: read` is the most minimal and appropriate setting. Add the following to the job definition just above its `steps` key:

```yaml
permissions:
  contents: read
```

Insert this block at line 178, after `runs-on: ubuntu-latest` and before the `steps:` block, in the `verify` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
